### PR TITLE
fixed incorrect number of columns in tournaments.csv

### DIFF
--- a/data/64/Singles/tournaments.csv
+++ b/data/64/Singles/tournaments.csv
@@ -14,5 +14,5 @@ WTFox 2,wtfox-2,2016-07-02,2016-07-04,25
 Don't Park On The Grass,don-t-park-on-the-grass,2016-12-17,2016-12-19,73
 Smash'N'Splash 2,smash-n-splash-2-1,2016-06-11,2016-06-12,47
 Super Smash Con 2016,super-smash-con-2016,2016-08-11,2016-08-14,314
-Smash Valley V Featuring Lucky, Abate, Swedish Delight, Wadi & More!,smash-valley-v,2017-02-18,2017-02-18,16
+Smash Valley V Featuring Lucky; Abate; Swedish Delight; Wadi & More!,smash-valley-v,2017-02-18,2017-02-18,16
 BEAST 7,beast-7,2017-02-17,2017-02-18,43


### PR DESCRIPTION
Row 17 was
`Smash Valley V Featuring Lucky, Abate, Swedish Delight, Wadi & More!,smash-valley-v,2017-02-18,2017-02-18,16`
but the commas between player names were messing things up. Changed them to semi-colons:
`Smash Valley V Featuring Lucky; Abate; Swedish Delight; Wadi & More!,smash-valley-v,2017-02-18,2017-02-18,16`